### PR TITLE
Fixed spanish translations

### DIFF
--- a/src/SfResources.es.resx
+++ b/src/SfResources.es.resx
@@ -211,7 +211,7 @@
     <value>Cancelar</value>
   </data>
   <data name="Uploader_Clear" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="Uploader_Delete" xml:space="preserve">
     <value>Borrar archivo</value>
@@ -1414,10 +1414,10 @@
     <value>Gráfico</value>
   </data>
   <data name="PivotView_Clear" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="PivotView_ClearFilter" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="PivotView_Close" xml:space="preserve">
     <value>Cerca</value>
@@ -2233,7 +2233,7 @@
     <value>Tachado</value>
   </data>
   <data name="RichTextEditor_ClearFormat" xml:space="preserve">
-    <value>Formato claro</value>
+    <value>Limpiar Formato</value>
   </data>
   <data name="RichTextEditor_ClearAll" xml:space="preserve">
     <value>Limpiar todo</value>
@@ -2734,7 +2734,7 @@
     <value>Filtrar</value>
   </data>
   <data name="Grid_ClearButton" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="Grid_StartsWith" xml:space="preserve">
     <value>Comienza con</value>
@@ -2830,7 +2830,7 @@
     <value>No se encontraron coincidencias</value>
   </data>
   <data name="Grid_ClearFilter" xml:space="preserve">
-    <value>Filtro claro</value>
+    <value>Limpiar Filtro</value>
   </data>
   <data name="Grid_NumberFilter" xml:space="preserve">
     <value>Filtros de número</value>


### PR DESCRIPTION
The translation of the word "clear" was translated as "claro". The right word in this case is "limpiar"
Updated SfResources.es.resx