### PR TITLE
Fixed spanish translations

### DIFF
--- a/src/SfResources.es.resx
+++ b/src/SfResources.es.resx
@@ -205,7 +205,7 @@
     <value>Abortar</value>
   </data>
   <data name="Uploader_Browse" xml:space="preserve">
-    <value>Vistazo...</value>
+    <value>Buscar...</value>
   </data>
   <data name="Uploader_Cancel" xml:space="preserve">
     <value>Cancelar</value>
@@ -2395,7 +2395,7 @@
     <value>Texto alternativo</value>
   </data>
   <data name="RichTextEditor_Browse" xml:space="preserve">
-    <value>Vistazo</value>
+    <value>Buscar</value>
   </data>
   <data name="RichTextEditor_ImageUrl" xml:space="preserve">
     <value>http://example.com/image.png</value>


### PR DESCRIPTION
The translation of the word "browse" was translated as "vistazo". The right word in this case is "buscar"
Updated SfResources.es.resx