### PR TITLE
Few Polish translations improvements

### DIFF
--- a/src/SfResources.pl.resx
+++ b/src/SfResources.pl.resx
@@ -283,13 +283,13 @@
     <value>Pobieranie</value>
   </data>
   <data name="FileManager_Cut" xml:space="preserve">
-    <value>Skaleczenie</value>
+    <value>Wytnij</value>
   </data>
   <data name="FileManager_Copy" xml:space="preserve">
     <value>Kopiuj</value>
   </data>
   <data name="FileManager_Paste" xml:space="preserve">
-    <value>Pasta</value>
+    <value>Wklej</value>
   </data>
   <data name="FileManager_SortBy" xml:space="preserve">
     <value>Sortuj według</value>
@@ -331,13 +331,13 @@
     <value>Pobieranie</value>
   </data>
   <data name="FileManager_TooltipCut" xml:space="preserve">
-    <value>Skaleczenie</value>
+    <value>Wytnij</value>
   </data>
   <data name="FileManager_TooltipCopy" xml:space="preserve">
     <value>Kopiuj</value>
   </data>
   <data name="FileManager_TooltipPaste" xml:space="preserve">
-    <value>Pasta</value>
+    <value>Wklej</value>
   </data>
   <data name="FileManager_TooltipSortBy" xml:space="preserve">
     <value>Sortuj według</value>
@@ -412,7 +412,7 @@
     <value>Anuluj</value>
   </data>
   <data name="FileManager_ButtonYes" xml:space="preserve">
-    <value>tak</value>
+    <value>Tak</value>
   </data>
   <data name="FileManager_ButtonNo" xml:space="preserve">
     <value>Nie</value>
@@ -553,7 +553,7 @@
     <value>Resetowanie</value>
   </data>
   <data name="Chart_Pan" xml:space="preserve">
-    <value>Patelnia</value>
+    <value>Przesuń</value>
   </data>
   <data name="Chart_ResetZoom" xml:space="preserve">
     <value>Zresetuj powiększenie</value>
@@ -577,7 +577,7 @@
     <value>Resetowanie</value>
   </data>
   <data name="Maps_Pan" xml:space="preserve">
-    <value>Patelnia</value>
+    <value>Przesuń</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>Powyżej</value>
@@ -2245,13 +2245,13 @@
     <value>Wyczyść wszystko</value>
   </data>
   <data name="RichTextEditor_Cut" xml:space="preserve">
-    <value>Skaleczenie</value>
+    <value>Wytnij</value>
   </data>
   <data name="RichTextEditor_Copy" xml:space="preserve">
     <value>Kopiuj</value>
   </data>
   <data name="RichTextEditor_Paste" xml:space="preserve">
-    <value>Pasta</value>
+    <value>Wklej</value>
   </data>
   <data name="RichTextEditor_UnorderedList" xml:space="preserve">
     <value>Lista wypunktowana</value>
@@ -2587,7 +2587,7 @@
     <value>Kopiuj</value>
   </data>
   <data name="Diagram_Cut" xml:space="preserve">
-    <value>Skaleczenie</value>
+    <value>Wytnij</value>
   </data>
   <data name="Diagram_Group" xml:space="preserve">
     <value>Grupa</value>
@@ -2602,7 +2602,7 @@
     <value>Zamówienie</value>
   </data>
   <data name="Diagram_Paste" xml:space="preserve">
-    <value>Pasta</value>
+    <value>Wklej</value>
   </data>
   <data name="Diagram_Redo" xml:space="preserve">
     <value>Przerobić</value>
@@ -3415,7 +3415,7 @@
     <value> Wybór </value>
   </data>
   <data name="PdfViewer_PanText" xml:space="preserve">
-    <value> Patelnia </value>
+    <value> Przesuń </value>
   </data>
   <data name="PdfViewer_PrintText" xml:space="preserve">
     <value> Wydrukować </value>
@@ -3466,10 +3466,10 @@
     <value> Diamentowa strzała</value>
   </data>
   <data name="PdfViewer_Cut" xml:space="preserve">
-    <value> Skaleczenie</value>
+    <value> Wytnij</value>
   </data>
   <data name="PdfViewer_Paste" xml:space="preserve">
-    <value> Pasta</value>
+    <value> Wklej</value>
   </data>
   <data name="PdfViewer_DeleteContext" xml:space="preserve">
     <value> Usunąć </value>
@@ -4126,13 +4126,13 @@
     <value>italski</value>
   </data>
   <data name="DocumentEditor_Cut" xml:space="preserve">
-    <value>Skaleczenie</value>
+    <value>Wytnij</value>
   </data>
   <data name="DocumentEditor_Copy" xml:space="preserve">
     <value>Kopiuj</value>
   </data>
   <data name="DocumentEditor_Paste" xml:space="preserve">
-    <value>Pasta</value>
+    <value>Wklej</value>
   </data>
   <data name="DocumentEditor_Hyperlink" xml:space="preserve">
     <value>Hiperłącze</value>


### PR DESCRIPTION
Paste as in paste the text / file was translated as Paste as in a substance. I think it should be the former meaning.
Cut as in cut and paste was translated as a cut on your body.
Translation of FileManager_ButtonYes was not capitalized but translation of FileManager_ButtonNo was, I made it both capitalized
Pan was translated as if it was a Pan for cooking.