### PR TITLE
Persian locale changes in grid

### DIFF
--- a/src/SfResources.fa.resx
+++ b/src/SfResources.fa.resx
@@ -2425,7 +2425,7 @@
     <value>نمایش سطرها در جایی:</value>
   </data>
   <data name="Pager_CurrentPageInfo" xml:space="preserve">
-    <value>{0} از 1 {صفحه</value>
+    <value>{0} از {1} صفحه</value>
   </data>
   <data name="Pager_TotalItemsInfo" xml:space="preserve">
     <value>({0} مورد)</value>

--- a/src/SfResources.ms.resx
+++ b/src/SfResources.ms.resx
@@ -2226,7 +2226,7 @@
   <data name="Grid_GroupDropArea" xml:space="preserve">
     <value>열 머리글을 여기로 끌어 열을 그룹화하십시오</value>
   </data>
-  <data name="Grid_UnGroup" xml:space="preserve">
+  <data name="Grid_UnGroupButton" xml:space="preserve">
     <value>그룹을 해제하려면 여기를 클릭하십시오</value>
   </data>
   <data name="Grid_GroupDisable" xml:space="preserve">

--- a/src/SfResources.nb.resx
+++ b/src/SfResources.nb.resx
@@ -2226,7 +2226,7 @@
   <data name="Grid_GroupDropArea" xml:space="preserve">
     <value>Dra en kolonneoverskrift hit for å gruppere kolonnen</value>
   </data>
-  <data name="Grid_UnGroup" xml:space="preserve">
+  <data name="Grid_UnGroupButton" xml:space="preserve">
     <value>Klikk her for å gruppere</value>
   </data>
   <data name="Grid_GroupDisable" xml:space="preserve">

--- a/src/SfResources.pt.resx
+++ b/src/SfResources.pt.resx
@@ -2226,6 +2226,9 @@
   <data name="Grid_GroupDropArea" xml:space="preserve">
     <value>Arraste um cabeçalho de coluna aqui para agrupar sua coluna</value>
   </data>
+  <data name="Grid_UnGroupButton" xml:space="preserve">
+    <value>Clique aqui para desagrupar</value>
+  </data>
   <data name="Grid_GroupDisable" xml:space="preserve">
     <value>O agrupamento está desativado para esta coluna</value>
   </data>


### PR DESCRIPTION
Exception is thrown when enabling paging in a grid with Persian locale it's because of the wrong value assigned for pager component now I have corrected that mistake.

Also, duplicate locale keys present in some locale files so change the corresponding locale key to resolve the problem.