### PR TITLE
bug: BLAZ-12698-German translation for clear button

### DIFF
--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -1063,7 +1063,7 @@
     <value>Filter</value>
   </data>
   <data name="Grid_ClearButton" xml:space="preserve">
-    <value>klar</value>
+    <value>Zurücksetzen</value>
   </data>
   <data name="Grid_StartsWith" xml:space="preserve">
     <value>Beginnt mit</value>


### PR DESCRIPTION
In German clear means "Zurücksetzen". "Klar" is used for water so we changed the corresponding value