### PR TITLE
Updated Kanban translation

### DIFF
--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -568,7 +568,7 @@
     <value>Erstellen</value>
   </data>
   <data name="FileManager_ButtonSave" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="FileManager_HeaderNewFolder" xml:space="preserve">
     <value>Mappe</value>
@@ -787,7 +787,7 @@
     <value>Aufgabeninformationen</value>
   </data>
   <data name="Gantt_SaveButton" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Gantt_Add" xml:space="preserve">
     <value>Hinzufügen</value>
@@ -904,7 +904,7 @@
     <value>Konvertieren</value>
   </data>
   <data name="Gantt_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>Über</value>
@@ -1009,7 +1009,7 @@
     <value>Säulen</value>
   </data>
   <data name="Grid_Save" xml:space="preserve">
-    <value>Sparen</value>
+    <value>Speichern</value>
   </data>
   <data name="Grid_Item" xml:space="preserve">
     <value>Artikel</value>
@@ -1024,7 +1024,7 @@
     <value>Keine Datensätze zum Löschen ausgewählt</value>
   </data>
   <data name="Grid_SaveButton" xml:space="preserve">
-    <value>Sparen</value>
+    <value>Speichern</value>
   </data>
   <data name="Grid_OKButton" xml:space="preserve">
     <value>OK</value>
@@ -1381,7 +1381,7 @@
     <value>Zwei Ereignisse desselben Ereignisses können nicht am selben Tag auftreten.</value>
   </data>
   <data name="Schedule_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Tab_CloseButtonTitle" xml:space="preserve">
     <value>Schließen</value>
@@ -1498,7 +1498,7 @@
     <value>Jahre)</value>
   </data>
   <data name="Schedule_SaveButton" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Schedule_SelectedItems" xml:space="preserve">
     <value>Elemente ausgewählt</value>
@@ -2380,7 +2380,7 @@
     <value>Schließen</value>
   </data>
   <data name="InPlaceEditor_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="InPlaceEditor_Cancel" xml:space="preserve">
     <value>Stornieren</value>
@@ -2398,10 +2398,10 @@
     <value>Doppelklick zum bearbeiten</value>
   </data>
   <data name="Kanban_Items" xml:space="preserve">
-    <value>Artikel</value>
+    <value>Elemente</value>
   </data>
   <data name="Kanban_Min" xml:space="preserve">
-    <value>Mindest</value>
+    <value>Min</value>
   </data>
   <data name="Kanban_Max" xml:space="preserve">
     <value>Max</value>
@@ -2410,10 +2410,10 @@
     <value>Karten ausgewählt</value>
   </data>
   <data name="Kanban_AddTitle" xml:space="preserve">
-    <value>Add New Card</value>
+    <value>Neue Karte hinzufügen</value>
   </data>
   <data name="Kanban_EditTitle" xml:space="preserve">
-    <value>Neue Karte hinzufügen</value>
+    <value>Karte bearbeiten</value>
   </data>
   <data name="Kanban_DeleteTitle" xml:space="preserve">
     <value>Karte löschen</value>
@@ -2422,19 +2422,22 @@
     <value>Möchten Sie diese Karte wirklich löschen?</value>
   </data>
   <data name="Kanban_Save" xml:space="preserve">
-    <value>sparen</value>
+    <value>Speichern</value>
   </data>
   <data name="Kanban_Delete" xml:space="preserve">
     <value>Löschen</value>
   </data>
   <data name="Kanban_Cancel" xml:space="preserve">
-    <value>Stornieren</value>
+    <value>Abbrechen</value>
   </data>
   <data name="Kanban_Yes" xml:space="preserve">
     <value>Ja</value>
   </data>
   <data name="Kanban_No" xml:space="preserve">
     <value>Nein</value>
+  </data>
+  <data name="Kanban_No_Cards" xml:space="preserve">
+    <value>Keine Karten vorhanden</value>
   </data>
   <data name="RichTextEditor_NumberFormatListNone" xml:space="preserve">
     <value> Keiner </value>
@@ -3907,7 +3910,7 @@
     <value>Formattyp</value>
   </data>
   <data name="DocumentEditor_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="DocumentEditor_Navigation" xml:space="preserve">
     <value>Navigation</value>


### PR DESCRIPTION
Updated the German translation of the Kanban component and some related translations

Description of all changes:

- Added the translation for Kanban_No_Cards for the text that is displayed when no cards are presented
- Changed the translation for Kanban_AddTitle and Kanban_EditTitle (Kanban_EditTitle had the German for adding a card and Kanban_AddTitle was English)
- Changed Kanban_Items from Artikel wich is something that you sell in German to Element which is more fitting
- Changed Kanban_Min from Mindest to Min (abbreviation)
- Changed Kanban_Save from sparen which is saving money to Speichern and changed it on every occurence of save
- Changed Kanban_Cancel from Stornieren to Abbrechen as this is more commonly using in software applications