### PR TITLE
bug(BLAZ-19633): Dialog, kanban, In-place Editor locale constant changes committed

### DIFF
--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -2392,7 +2392,7 @@
     <value>Schließen</value>
   </data>
   <data name="InPlaceEditor_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="InPlaceEditor_Cancel" xml:space="preserve">
     <value>Stornieren</value>
@@ -2410,7 +2410,7 @@
     <value>Doppelklick zum bearbeiten</value>
   </data>
   <data name="Kanban_Items" xml:space="preserve">
-    <value>Aufgaben</value>
+    <value>Elemente</value>
   </data>
   <data name="Kanban_Item" xml:space="preserve">
     <value>Aufgabe</value>
@@ -2419,7 +2419,7 @@
     <value>Keine Karten zum Anzeigen</value>
   </data>
   <data name="Kanban_Min" xml:space="preserve">
-    <value>Mindest</value>
+    <value>Min</value>
   </data>
   <data name="Kanban_Max" xml:space="preserve">
     <value>Max</value>
@@ -2428,10 +2428,10 @@
     <value>Karten ausgewählt</value>
   </data>
   <data name="Kanban_AddTitle" xml:space="preserve">
-    <value>Add New Card</value>
+    <value>Neue Karte hinzufügen</value>
   </data>
   <data name="Kanban_EditTitle" xml:space="preserve">
-    <value>Neue Karte hinzufügen</value>
+    <value>Karte bearbeiten</value>
   </data>
   <data name="Kanban_DeleteTitle" xml:space="preserve">
     <value>Karte löschen</value>
@@ -2440,19 +2440,22 @@
     <value>Möchten Sie diese Karte wirklich löschen?</value>
   </data>
   <data name="Kanban_Save" xml:space="preserve">
-    <value>sparen</value>
+    <value>Speichern</value>
   </data>
   <data name="Kanban_Delete" xml:space="preserve">
     <value>Löschen</value>
   </data>
   <data name="Kanban_Cancel" xml:space="preserve">
-    <value>Stornieren</value>
+    <value>Abbrechen</value>
   </data>
   <data name="Kanban_Yes" xml:space="preserve">
     <value>Ja</value>
   </data>
   <data name="Kanban_No" xml:space="preserve">
     <value>Nein</value>
+  </data>
+  <data name="Kanban_No_Cards" xml:space="preserve">
+    <value>Keine Karten vorhanden</value>
   </data>
   <data name="RichTextEditor_NumberFormatListNone" xml:space="preserve">
     <value> Keiner </value>

--- a/src/SfResources.nl.resx
+++ b/src/SfResources.nl.resx
@@ -1756,7 +1756,7 @@
     <value>dit veld is verplicht</value>
   </data>
   <data name="Dialog_Close" xml:space="preserve">
-    <value>Dichtbij</value>
+    <value>Sluiten</value>
   </data>
   <data name="Toast_Close" xml:space="preserve">
     <value>Dichtbij</value>


### PR DESCRIPTION
Following customer provided locale constants changes committed

**Issue 1:**
- The Close button in a Dialog (Top Right). When you hover over it, it is translated as "Dichtbij" While this means "Nearby". The correct translation should be "Sluiten"

**Issue 2:**

Updated the German translation of the Kanban component and some related translations

Description of all changes:

Added the translation for Kanban_No_Cards for the text that is displayed when no cards are presented
Changed the translation for Kanban_AddTitle and Kanban_EditTitle (Kanban_EditTitle had the German for adding a card and Kanban_AddTitle was English)
Changed Kanban_Items from Artikel wich is something that you sell in German to Element which is more fitting
Changed Kanban_Min from Mindest to Min (abbreviation)
Changed Kanban_Save from sparen which is saving money to Speichern and changed it on every occurence of save
Changed Kanban_Cancel from Stornieren to Abbrechen as this is more commonly using in software applications