### PR TITLE
bug(BLAZ-19648) : Save in German

### DIFF
--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -787,7 +787,7 @@
     <value>Aufgabeninformationen</value>
   </data>
   <data name="Gantt_SaveButton" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Gantt_Add" xml:space="preserve">
     <value>Hinzufügen</value>
@@ -904,7 +904,7 @@
     <value>Konvertieren</value>
   </data>
   <data name="Gantt_Save" xml:space="preserve">
-    <value>speichern</value>
+    <value>Speichern</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>Über</value>


### PR DESCRIPTION
Save word Changed in German Culture from **speichern** to **Speichern**