### PR TITLE
In Blazor File Manager, upload localized text is updated for the French culture.

### DIFF
--- a/src/SfResources.fr-CH.resx
+++ b/src/SfResources.fr-CH.resx
@@ -418,7 +418,7 @@
     <value>Nouveau dossier</value>
   </data>
   <data name="FileManager_Upload" xml:space="preserve">
-    <value>Télécharger</value>
+    <value>Téléverser</value>
   </data>
   <data name="FileManager_Delete" xml:space="preserve">
     <value>Supprimer</value>

--- a/src/SfResources.fr.resx
+++ b/src/SfResources.fr.resx
@@ -271,7 +271,7 @@
 	  <value>Nouveau dossier</value>
   </data>
   <data name="FileManager_Upload" xml:space="preserve">
-    <value>Télécharger</value>
+    <value>Téléverser</value>
   </data>
   <data name="FileManager_Delete" xml:space="preserve">
     <value>Supprimer</value>


### PR DESCRIPTION
Updated the proper localized text for file manager upload in French culture.

```
<value>Téléverser</value>
```