### PR TITLE
bug(BLAZ-19759): Blazor grid locale changes

### DIFF
--- a/src/SfResources.pt.resx
+++ b/src/SfResources.pt.resx
@@ -2355,7 +2355,7 @@
   <data name="Grid_GroupDropArea" xml:space="preserve">
     <value>Arraste um cabeçalho de coluna aqui para agrupar sua coluna</value>
   </data>
-  <data name="Grid_UnGroup" xml:space="preserve">
+  <data name="Grid_UnGroupButton" xml:space="preserve">
     <value>Clique aqui para desagrupar</value>
   </data>
   <data name="Grid_GroupDisable" xml:space="preserve">


### PR DESCRIPTION
Williams customer provided locale constants changes committed,

https://github.com/syncfusion/blazor-locale/pull/42/files

Here, we have changed Grid_UnGroupButton which is wrongly defined

However, Grid_UnGroup should be as Grid_Ungroup. So, this change not required. 