### PR TITLE
Fix some bad translations in spanish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+src/SfResources.Designer.cs

--- a/src/SfResources.es.resx
+++ b/src/SfResources.es.resx
@@ -148,7 +148,7 @@
     <value>Rango personalizado</value>
   </data>
   <data name="DateRangePicker_Days" xml:space="preserve">
-    <value>Dias</value>
+    <value>Días</value>
   </data>
   <data name="DateRangePicker_EndLabel" xml:space="preserve">
     <value>Fecha final</value>
@@ -174,19 +174,19 @@
   <data name="Date_Month" xml:space="preserve">
     <value>Mes</value>
   </data>
-   <data name="Date_Year" xml:space="preserve">
+  <data name="Date_Year" xml:space="preserve">
     <value>Año</value>
   </data>
-   <data name="Time_Hour" xml:space="preserve">
+  <data name="Time_Hour" xml:space="preserve">
     <value>Hora</value>
   </data>
-   <data name="Time_Minute" xml:space="preserve">
+  <data name="Time_Minute" xml:space="preserve">
     <value>Minuto</value>
   </data>
-   <data name="Time_Second" xml:space="preserve">
+  <data name="Time_Second" xml:space="preserve">
     <value>Segunda</value>
   </data>
-   <data name="Date_DayOfWeek" xml:space="preserve">
+  <data name="Date_DayOfWeek" xml:space="preserve">
     <value>Día de la semana</value>
   </data>
   <data name="DropDownList_ActionFailureTemplate" xml:space="preserve">
@@ -352,7 +352,7 @@
     <value>Eliminar</value>
   </data>
   <data name="FileManager_TooltipRename" xml:space="preserve">
-    <value>Rebautizar</value>
+    <value>Renombrar</value>
   </data>
   <data name="FileManager_TooltipDownload" xml:space="preserve">
     <value>Descargar</value>
@@ -388,7 +388,7 @@
     <value>Nombre</value>
   </data>
   <data name="FileManager_Size" xml:space="preserve">
-    <value>Talla</value>
+    <value>Tamaño</value>
   </data>
   <data name="FileManager_DateModified" xml:space="preserve">
     <value>Modificado</value>
@@ -664,7 +664,7 @@
     <value>minuto</value>
   </data>
   <data name="Gantt_Days" xml:space="preserve">
-    <value>Dias</value>
+    <value>Días</value>
   </data>
   <data name="Gantt_Hours" xml:space="preserve">
     <value>horas</value>
@@ -688,7 +688,7 @@
     <value>Información de tarea</value>
   </data>
   <data name="Gantt_SaveButton" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Gantt_Add" xml:space="preserve">
     <value>añadir</value>
@@ -742,7 +742,7 @@
     <value>Periodo de tiempo anterior</value>
   </data>
   <data name="Gantt_OkText" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="Gantt_ConfirmDelete" xml:space="preserve">
     <value>¿Estás seguro de que deseas eliminar el registro?</value>
@@ -805,7 +805,7 @@
     <value>Convertir</value>
   </data>
   <data name="Gantt_Save" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>Encima</value>
@@ -814,7 +814,7 @@
     <value>Abajo</value>
   </data>
   <data name="Gantt_Child" xml:space="preserve">
-    <value>Niño</value>
+    <value>Hijo</value>
   </data>
   <data name="Gantt_Milestone" xml:space="preserve">
     <value>Hito</value>
@@ -844,7 +844,7 @@
     <value>Sangrar</value>
   </data>
   <data name="Gantt_Outdent" xml:space="preserve">
-    <value>Outdent</value>
+    <value>Anular la sangría</value>
   </data>
   <data name="Gantt_AutoFit" xml:space="preserve">
     <value>Columna de ajuste automático</value>
@@ -913,7 +913,7 @@
     <value>Alternar formato</value>
   </data>
   <data name="ColorPicker" xml:space="preserve">
-    <value>Farbwähler</value>
+    <value>Selector de color</value>
   </data>
   <data name="SplitButton" xml:space="preserve">
     <value>Split-Taste</value>
@@ -1114,16 +1114,16 @@
     <value>Gráfico</value>
   </data>
   <data name="PivotView_Clear" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="PivotView_ClearFilter" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar filtro</value>
   </data>
   <data name="PivotView_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="PivotView_Collapse" xml:space="preserve">
-    <value>Colapso</value>
+    <value>Colapsar</value>
   </data>
   <data name="PivotView_Column" xml:space="preserve">
     <value>Columna</value>
@@ -1384,7 +1384,7 @@
     <value>Línea</value>
   </data>
   <data name="PivotView_LoadReport" xml:space="preserve">
-    <value>Carga</value>
+    <value>Cargar Informe</value>
   </data>
   <data name="PivotView_ManageRecords" xml:space="preserve">
     <value>Administrar registros</value>
@@ -1456,7 +1456,7 @@
     <value>de</value>
   </data>
   <data name="PivotView_OK" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="PivotView_OutOfRange" xml:space="preserve">
     <value>Fuera de rango</value>
@@ -1510,13 +1510,13 @@
     <value>Producto</value>
   </data>
   <data name="PivotView_Quarter" xml:space="preserve">
-    <value>Qtr</value>
+    <value>Cuarto</value>
   </data>
   <data name="PivotView_Quarters" xml:space="preserve">
-    <value>Cuarteles</value>
+    <value>Cuartos</value>
   </data>
   <data name="PivotView_QuarterYear" xml:space="preserve">
-    <value>Cuarto año</value>
+    <value>Cuarto de año</value>
   </data>
   <data name="PivotView_Remove" xml:space="preserve">
     <value>Eliminar</value>
@@ -1852,16 +1852,16 @@
     <value>este campo es requerido</value>
   </data>
   <data name="Dialog_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="Message_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="Toast_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="InPlaceEditor_Save" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="InPlaceEditor_Cancel" xml:space="preserve">
     <value>Cancelar</value>
@@ -1909,7 +1909,7 @@
     <value>¿Estás segura de que quieres eliminar esta tarjeta?</value>
   </data>
   <data name="Kanban_Save" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Kanban_Delete" xml:space="preserve">
     <value>Eliminar</value>
@@ -2385,14 +2385,13 @@
   <data name="RichTextEditor_PasteDialogCancel" xml:space="preserve">
     <value>Cancelar</value>
   </data>
-
   <data name="RichTextEditor_Audio_Replace" xml:space="preserve">
     <value>Reemplazar</value>
   </data>
   <data name="RichTextEditor_Audio_Remove" xml:space="preserve">
     <value>Remover</value>
   </data>
-   <data name="RichTextEditor_Audio_Display" xml:space="preserve">
+  <data name="RichTextEditor_Audio_Display" xml:space="preserve">
     <value>Monitora</value>
   </data>
   <data name="RichTextEditor_Video_Replace" xml:space="preserve">
@@ -2410,7 +2409,6 @@
   <data name="RichTextEditor_Video_Dimension" xml:space="preserve">
     <value>Dimensión</value>
   </data>
-
   <data name="DiagramComponent_X" xml:space="preserve">
     <value>X</value>
   </data>
@@ -2457,10 +2455,10 @@
     <value>Enviar atrás</value>
   </data>
   <data name="Diagram_SendToBack" xml:space="preserve">
-    <value>Send To Back</value>
+    <value>Enviar al fondo</value>
   </data>
   <data name="Diagram_Undo" xml:space="preserve">
-    <value>Mandado hacia atras</value>
+    <value>Deshacer</value>
   </data>
   <data name="Diagram_UnGroup" xml:space="preserve">
     <value>Desagrupar</value>
@@ -2529,7 +2527,7 @@
     <value>Columnas</value>
   </data>
   <data name="Grid_Save" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Grid_Item" xml:space="preserve">
     <value>articulo</value>
@@ -2544,10 +2542,10 @@
     <value>No hay registros seleccionados para la operación de eliminación</value>
   </data>
   <data name="Grid_SaveButton" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Grid_OKButton" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="Grid_CancelButton" xml:space="preserve">
     <value>Cancelar</value>
@@ -2583,7 +2581,7 @@
     <value>Filtrar</value>
   </data>
   <data name="Grid_ClearButton" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpiar</value>
   </data>
   <data name="Grid_StartsWith" xml:space="preserve">
     <value>Comienza con</value>
@@ -2679,7 +2677,7 @@
     <value>No se encontraron coincidencias</value>
   </data>
   <data name="Grid_ClearFilter" xml:space="preserve">
-    <value>Filtro claro</value>
+    <value>Limpiar filtro</value>
   </data>
   <data name="Grid_NumberFilter" xml:space="preserve">
     <value>Filtros de número</value>
@@ -2846,7 +2844,7 @@
   <data name="Pager_All" xml:space="preserve">
     <value>Todos</value>
   </data>
-   <data name="Pager_Items" xml:space="preserve">
+  <data name="Pager_Items" xml:space="preserve">
     <value>artículos</value>
   </data>
   <data name="RecurrenceEditor_Count" xml:space="preserve">
@@ -2856,7 +2854,7 @@
     <value>Diario</value>
   </data>
   <data name="RecurrenceEditor_Days" xml:space="preserve">
-    <value>Dias)</value>
+    <value>Días)</value>
   </data>
   <data name="RecurrenceEditor_End" xml:space="preserve">
     <value>Final</value>
@@ -2916,7 +2914,7 @@
     <value>Segundo</value>
   </data>
   <data name="RecurrenceEditor_SummaryDay" xml:space="preserve">
-    <value>dias)</value>
+    <value>días)</value>
   </data>
   <data name="RecurrenceEditor_SummaryMonth" xml:space="preserve">
     <value>meses)</value>
@@ -2985,7 +2983,7 @@
     <value>Cancelar</value>
   </data>
   <data name="Schedule_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="Schedule_CreateError" xml:space="preserve">
     <value>La duración del evento debe ser más corta que la frecuencia con la que ocurre. Acorte la duración o cambie el patrón de recurrencia en el editor de eventos de recurrencia.</value>
@@ -3102,7 +3100,7 @@
     <value>Ocurrencia</value>
   </data>
   <data name="Schedule_Ok" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="Schedule_Previous" xml:space="preserve">
     <value>Anterior</value>
@@ -3120,10 +3118,10 @@
     <value>Dos ocurrencias del mismo evento no pueden ocurrir en el mismo día.</value>
   </data>
   <data name="Schedule_Save" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Schedule_SaveButton" xml:space="preserve">
-    <value>Salvar</value>
+    <value>Guardar</value>
   </data>
   <data name="Schedule_SelectedItems" xml:space="preserve">
     <value>Artículos seleccionados</value>
@@ -3201,7 +3199,7 @@
     <value>Año</value>
   </data>
   <data name="Tab_CloseButtonTitle" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="Carousel_PreviousSlide" xml:space="preserve">
     <value>diapositiva anterior</value>
@@ -3228,7 +3226,7 @@
     <value>Visor de PDF</value>
   </data>
   <data name="PdfViewer_Cancel" xml:space="preserve">
-    <value>Cancelar l</value>
+    <value>Cancelar</value>
   </data>
   <data name="PdfViewer_DownloadFile" xml:space="preserve">
     <value>Descargar archivo</value>
@@ -3267,7 +3265,7 @@
     <value>Mostrar página anterior</value>
   </data>
   <data name="PdfViewer_OK" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="PdfViewer_Open" xml:space="preserve">
     <value>Abrir documento</value>
@@ -3582,7 +3580,7 @@
     <value>Añadir</value>
   </data>
   <data name="PdfViewer_Clear" xml:space="preserve">
-    <value>Clara</value>
+    <value>Limpiar</value>
   </data>
   <data name="PdfViewer_Bold" xml:space="preserve">
     <value>Negrito</value>
@@ -3753,7 +3751,7 @@
     <value>Célula</value>
   </data>
   <data name="DocumentEditor_Ok" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="DocumentEditor_Cancel" xml:space="preserve">
     <value>Cancelar</value>
@@ -3915,7 +3913,7 @@
     <value>Orientación</value>
   </data>
   <data name="DocumentEditor_Landscape" xml:space="preserve">
-    <value>Paisaje</value>
+    <value>Apaisado</value>
   </data>
   <data name="DocumentEditor_Portrait" xml:space="preserve">
     <value>Retrato</value>
@@ -3951,7 +3949,7 @@
     <value>Nivel de TOC</value>
   </data>
   <data name="DocumentEditor_Heading" xml:space="preserve">
-    <value>Bóveda</value>
+    <value>Título</value>
   </data>
   <data name="DocumentEditor_Heading1" xml:space="preserve">
     <value>Título 1</value>
@@ -4140,7 +4138,7 @@
     <value>UpRoman</value>
   </data>
   <data name="DocumentEditor_LowRoman" xml:space="preserve">
-    <value>LowRoman</value>
+    <value>Roman baja</value>
   </data>
   <data name="DocumentEditor_UpLetter" xml:space="preserve">
     <value>UpLetter</value>
@@ -4317,7 +4315,7 @@
     <value>Nombre del marcador</value>
   </data>
   <data name="DocumentEditor_Close" xml:space="preserve">
-    <value>Cerca</value>
+    <value>Cerrar</value>
   </data>
   <data name="DocumentEditor_RestartAt" xml:space="preserve">
     <value>Reiniciar en</value>
@@ -4761,7 +4759,7 @@
     <value>Desproteger documento</value>
   </data>
   <data name="DocumentEditor_FormFieldsOnly" xml:space="preserve">
-    <value>Solo puede completar formularios en esta región.</value>
+    <value>Solo campos de formularios en esta región.</value>
   </data>
   <data name="DocumentEditor_IndentsAndSpacing" xml:space="preserve">
     <value>Control de viudas / huérfanos</value>
@@ -4782,185 +4780,185 @@
     <value>Mantener con el siguiente</value>
   </data>
   <data name="DocumentEditor_ScreenTip" xml:space="preserve">
-       <value>Texto de información en pantalla</value>
-</data>
+    <value>Texto de información en pantalla</value>
+  </data>
   <data name="DocumentEditor_KeepSource" xml:space="preserve">
-       <value>Mantener el formato de origen</value>
-</data>
+    <value>Mantener el formato de origen</value>
+  </data>
   <data name="DocumentEditor_DestinationFormat" xml:space="preserve">
-       <value>Hacer coincidir el formato de destino</value>
-</data>
+    <value>Hacer coincidir el formato de destino</value>
+  </data>
   <data name="DocumentEditor_CommentsOnly" xml:space="preserve">
-       <value>Solo puede insertar comentarios en esta región.</value>
-</data>
+    <value>Solo puede insertar comentarios en esta región.</value>
+  </data>
   <data name="DocumentEditor_RowRange" xml:space="preserve">
-       <value>El número de filas debe estar entre 1 y 32767.</value>
-</data>
+    <value>El número de filas debe estar entre 1 y 32767.</value>
+  </data>
   <data name="DocumentEditor_ColumnRange" xml:space="preserve">
-       <value>El número de columnas debe estar entre 1 y 63.</value>
-</data>
+    <value>El número de columnas debe estar entre 1 y 63.</value>
+  </data>
   <data name="DocumentEditor_Information" xml:space="preserve">
-       <value>Información</value>
-</data>
+    <value>Información</value>
+  </data>
   <data name="DocumentEditor_Dot" xml:space="preserve">
-       <value>Punto</value>
-</data>
+    <value>Punto</value>
+  </data>
   <data name="DocumentEditor_DashSmallGap" xml:space="preserve">
-       <value>Brecha pequeña de guión</value>
-</data>
+    <value>Brecha pequeña de guión</value>
+  </data>
   <data name="DocumentEditor_DashDot" xml:space="preserve">
-       <value>Guion punto</value>
-</data>
+    <value>Guion punto</value>
+  </data>
   <data name="DocumentEditor_ThinThickSmallGap" xml:space="preserve">
-       <value>Delgado Grueso Pequeño Espacio</value>
-</data>
+    <value>Delgado Grueso Pequeño Espacio</value>
+  </data>
   <data name="DocumentEditor_ThickThinSmallGap" xml:space="preserve">
-       <value>Grueso Delgado Pequeño Espacio</value>
-</data>
+    <value>Grueso Delgado Pequeño Espacio</value>
+  </data>
   <data name="DocumentEditor_ThickThinMediumGap" xml:space="preserve">
-       <value>Grueso Delgado Medio Espacio</value>
-</data>
+    <value>Grueso Delgado Medio Espacio</value>
+  </data>
   <data name="DocumentEditor_ThickThinLargeGap" xml:space="preserve">
-       <value>Grueso Delgado Gran Brecha</value>
-</data>
+    <value>Grueso Delgado Gran Brecha</value>
+  </data>
   <data name="DocumentEditor_SingleWavy" xml:space="preserve">
-       <value>Solo ondulado</value>
-</data>
+    <value>Solo ondulado</value>
+  </data>
   <data name="DocumentEditor_DoubleWavy" xml:space="preserve">
-       <value>doble ondulado</value>
-</data>
+    <value>doble ondulado</value>
+  </data>
   <data name="DocumentEditor_Inset" xml:space="preserve">
-       <value>Recuadro</value>
-</data>
+    <value>Recuadro</value>
+  </data>
   <data name="DocumentEditor_DashLargeGap" xml:space="preserve">
-       <value>Brecha grande de guión</value>
-</data>
+    <value>Brecha grande de guión</value>
+  </data>
   <data name="DocumentEditor_DashDotDot" xml:space="preserve">
-       <value>Guión Punto Punto</value>
-</data>
+    <value>Guión Punto Punto</value>
+  </data>
   <data name="DocumentEditor_Triple" xml:space="preserve">
-       <value>Triple</value>
-</data>
+    <value>Triple</value>
+  </data>
   <data name="DocumentEditor_ThinThickThinSmallGap" xml:space="preserve">
-       <value>Delgado Grueso Delgado Pequeño Espacio</value>
-</data>
+    <value>Delgado Grueso Delgado Pequeño Espacio</value>
+  </data>
   <data name="DocumentEditor_ThinThickThinMediumGap" xml:space="preserve">
-       <value>Delgado Grueso Delgado Medio Espacio</value>
-</data>
+    <value>Delgado Grueso Delgado Medio Espacio</value>
+  </data>
   <data name="DocumentEditor_ThinThickThinLargeGap" xml:space="preserve">
-       <value>Delgado Grueso Delgado Gran Espacio</value>
-</data>
+    <value>Delgado Grueso Delgado Gran Espacio</value>
+  </data>
   <data name="DocumentEditor_DashDotStroked" xml:space="preserve">
-       <value>Guión punto acariciado</value>
-</data>
+    <value>Guión punto acariciado</value>
+  </data>
   <data name="DocumentEditor_Engrave3D" xml:space="preserve">
-       <value>Grabar3D</value>
-</data>
+    <value>Grabar 3D</value>
+  </data>
   <data name="DocumentEditor_Thick" xml:space="preserve">
-       <value>Grueso</value>
-</data>
+    <value>Grueso</value>
+  </data>
   <data name="DocumentEditor_Outset" xml:space="preserve">
-       <value>Comienzo</value>
-</data>
+    <value>Comienzo</value>
+  </data>
   <data name="DocumentEditor_Emboss3D" xml:space="preserve">
-       <value>Relieve 3D</value>
-</data>
+    <value>Relieve 3D</value>
+  </data>
   <data name="DocumentEditor_ThinThickLargeGap" xml:space="preserve">
-       <value>Delgado Grueso Gran Brecha</value>
-</data>
+    <value>Delgado Grueso Gran Brecha</value>
+  </data>
   <data name="DocumentEditor_ThinThickMediumGap" xml:space="preserve">
-       <value>Delgado Grueso Medio Espacio</value>
-</data>
+    <value>Delgado Grueso Medio Espacio</value>
+  </data>
   <data name="DocumentEditor_RegularText" xml:space="preserve">
-       <value>Texto normal</value>
-</data>
+    <value>Texto normal</value>
+  </data>
   <data name="DocumentEditor_Date" xml:space="preserve">
-       <value>Fecha</value>
-</data>
+    <value>Fecha</value>
+  </data>
   <data name="DocumentEditor_Uppercase" xml:space="preserve">
-       <value>Mayúsculas</value>
-</data>
+    <value>Mayúsculas</value>
+  </data>
   <data name="DocumentEditor_Lowercase" xml:space="preserve">
-       <value>Minúsculas</value>
-</data>
+    <value>Minúsculas</value>
+  </data>
   <data name="DocumentEditor_FirstCapital" xml:space="preserve">
-       <value>PrimeraCapital</value>
-</data>
+    <value>Primera capital</value>
+  </data>
   <data name="DocumentEditor_Titlecase" xml:space="preserve">
-       <value>Titulo del caso</value>
-</data>
+    <value>Titulo del caso</value>
+  </data>
   <data name="DocumentEditor_MoveFrom" xml:space="preserve">
-       <value>Moverse de</value>
-</data>
+    <value>Moverse de</value>
+  </data>
   <data name="DocumentEditor_MoveTo" xml:space="preserve">
-       <value>Mover a</value>
-</data>
+    <value>Mover a</value>
+  </data>
   <data name="DocumentEditor_Px" xml:space="preserve">
-       <value>píxeles</value>
-</data>
+    <value>píxeles</value>
+  </data>
   <data name="DocumentEditor_ReadOnlyProtection" xml:space="preserve">
-       <value>Puede editar en esta región.</value>
-</data>
-<data name="DocumentEditor_SectionBreakNextPage" xml:space="preserve">
-<value>Salto de sección (Página siguiente)</value>
-</data>
-<data name="DocumentEditor_PageBreak" xml:space="preserve">
-<value>Salto de página</value>
-</data>
-<data name="DocumentEditor_ColumnBreak" xml:space="preserve">
-<value>Salto de columna</value>
-</data>
-<data name="DocumentEditor_One" xml:space="preserve">
-<value>Una</value>
-</data>
-<data name="DocumentEditor_Two" xml:space="preserve">
-<value>Dos</value>
-</data>
-<data name="DocumentEditor_Three" xml:space="preserve">
-<value>Tres</value>
-</data>
-<data name="DocumentEditor_Presets" xml:space="preserve">
-<value>Preajustes</value>
-</data>
-<data name="DocumentEditor_Columns" xml:space="preserve">
-<value>columnas</value>
-</data>
-<data name="DocumentEditor_SplitToColumns" xml:space="preserve">
-<value>Divide tu texto en dos o más columnas</value>
-</data>
-<data name="DocumentEditor_LineBetweenColumn" xml:space="preserve">
-<value>Línea entre columna</value>
-</data>
-<data name="DocumentEditor_WidthAndSpacing" xml:space="preserve">
-<value>Ancho y espaciado</value>
-</data>
-<data name="DocumentEditor_EqualColumnWidth" xml:space="preserve">
-<value>Ancho de columna igual</value>
-</data>
-<data name="DocumentEditor_Column" xml:space="preserve">
-<value>Columna</value>
-</data>
-<data name="DocumentEditor_SectionBreakContinuous" xml:space="preserve">
-<value>Salto de sección (continuo)</value>
-</data>
-<data name="DocumentEditor_PasteContentDialog" xml:space="preserve">
-  <value>Debido a la política de seguridad del navegador, la función de pegar desde el portapapeles del sistema está restringida. Alternativamente, use el atajo de teclado</value>
-</data>
-<data name="DocumentEditor_PasteCheckBoxContentDialog" xml:space="preserve">
-  <value>no volver a mostrar</value>
-</data>
-<data name="DocumentEditorContainer_Columns" xml:space="preserve">
-<value>columnas</value>
-</data>
-<data name="DocumentEditorContainer_ShowHiddenMarks" xml:space="preserve">
-<value>Muestra los caracteres ocultos como espacios, tabulaciones, marcas de párrafo y saltos. (Ctrl + *)</value>
-</data>
+    <value>Puede editar en esta región.</value>
+  </data>
+  <data name="DocumentEditor_SectionBreakNextPage" xml:space="preserve">
+    <value>Salto de sección (Página siguiente)</value>
+  </data>
+  <data name="DocumentEditor_PageBreak" xml:space="preserve">
+    <value>Salto de página</value>
+  </data>
+  <data name="DocumentEditor_ColumnBreak" xml:space="preserve">
+    <value>Salto de columna</value>
+  </data>
+  <data name="DocumentEditor_One" xml:space="preserve">
+    <value>Una</value>
+  </data>
+  <data name="DocumentEditor_Two" xml:space="preserve">
+    <value>Dos</value>
+  </data>
+  <data name="DocumentEditor_Three" xml:space="preserve">
+    <value>Tres</value>
+  </data>
+  <data name="DocumentEditor_Presets" xml:space="preserve">
+    <value>Preajustes</value>
+  </data>
+  <data name="DocumentEditor_Columns" xml:space="preserve">
+    <value>columnas</value>
+  </data>
+  <data name="DocumentEditor_SplitToColumns" xml:space="preserve">
+    <value>Divide tu texto en dos o más columnas</value>
+  </data>
+  <data name="DocumentEditor_LineBetweenColumn" xml:space="preserve">
+    <value>Línea entre columna</value>
+  </data>
+  <data name="DocumentEditor_WidthAndSpacing" xml:space="preserve">
+    <value>Ancho y espaciado</value>
+  </data>
+  <data name="DocumentEditor_EqualColumnWidth" xml:space="preserve">
+    <value>Ancho de columna igual</value>
+  </data>
+  <data name="DocumentEditor_Column" xml:space="preserve">
+    <value>Columna</value>
+  </data>
+  <data name="DocumentEditor_SectionBreakContinuous" xml:space="preserve">
+    <value>Salto de sección (continuo)</value>
+  </data>
+  <data name="DocumentEditor_PasteContentDialog" xml:space="preserve">
+    <value>Debido a la política de seguridad del navegador, la función de pegar desde el portapapeles del sistema está restringida. Alternativamente, use el atajo de teclado</value>
+  </data>
+  <data name="DocumentEditor_PasteCheckBoxContentDialog" xml:space="preserve">
+    <value>no volver a mostrar</value>
+  </data>
+  <data name="DocumentEditorContainer_Columns" xml:space="preserve">
+    <value>columnas</value>
+  </data>
+  <data name="DocumentEditorContainer_ShowHiddenMarks" xml:space="preserve">
+    <value>Muestra los caracteres ocultos como espacios, tabulaciones, marcas de párrafo y saltos. (Ctrl + *)</value>
+  </data>
   <data name="DocumentEditorContainer_RegularTooltip" xml:space="preserve">
-       <value>Regular</value>
-</data>
+    <value>Regular</value>
+  </data>
   <data name="DocumentEditorContainer_BoldItalicTooltip" xml:space="preserve">
-       <value>Negrita cursiva</value>
-</data>
+    <value>Negrita cursiva</value>
+  </data>
   <data name="DocumentEditorContainer_New" xml:space="preserve">
     <value>Nuevo</value>
   </data>
@@ -5370,7 +5368,7 @@
     <value>diseño web</value>
   </data>
   <data name="DocumentEditorContainer_ToggleBetweenTheInternalClipboardAndSystemClipboard" xml:space="preserve">
-    <value>Alterne entre el portapapeles interno y el portapapeles del sistema. &#xD; El acceso al portapapeles del sistema a través del script está denegado debido a la política de seguridad de los navegadores. En su lugar, &#xD; 1. Puede habilitar el portapapeles interno para cortar, copiar y pegar dentro del componente. &#xD; 2. Puede usar los atajos de teclado (Ctrl + X, Ctrl + C y Ctrl + V) para cortar , copie y pegue con el portapapeles del sistema.</value>
+    <value>Alterne entre el portapapeles interno y el portapapeles del sistema.  El acceso al portapapeles del sistema a través del script está denegado debido a la política de seguridad de los navegadores. En su lugar,  1. Puede habilitar el portapapeles interno para cortar, copiar y pegar dentro del componente.  2. Puede usar los atajos de teclado (Ctrl + X, Ctrl + C y Ctrl + V) para cortar , copie y pegue con el portapapeles del sistema.</value>
   </data>
   <data name="DocumentEditorContainer_TextForm" xml:space="preserve">
     <value>Formulario de texto</value>
@@ -5433,7 +5431,7 @@
     <value>Puede editar en esta región, pero se realizará un seguimiento de todos los cambios</value>
   </data>
   <data name="DocumentEditor_UnsupportedFormat" xml:space="preserve">
-  	<value>El formato de archivo que ha seleccionado no es compatible. Elija un formato válido.</value>
+    <value>El formato de archivo que ha seleccionado no es compatible. Elija un formato válido.</value>
   </data>
   <data name="DocumentEditor_InvalidFile" xml:space="preserve">
     <value>Hubo un problema al abrir este documento</value>
@@ -5505,7 +5503,7 @@
     <value>Cargando...</value>
   </data>
   <data name="Dialog_OK" xml:space="preserve">
-    <value>Okay</value>
+    <value>Aceptar</value>
   </data>
   <data name="Dialog_Cancel" xml:space="preserve">
     <value>Cancelar</value>
@@ -5553,7 +5551,7 @@
     <value>Ir a la última página</value>
   </data>
   <data name="PivotView_GoToNextPage" xml:space="preserve">
-   <value>Ir a la página siguiente</value>
+    <value>Ir a la página siguiente</value>
   </data>
   <data name="PivotView_GoToPreviousPage" xml:space="preserve">
     <value>Regresar a la pagina anterior</value>


### PR DESCRIPTION
Close -> Cerrar (Correct) You close the window
Close -> Cerca (Incorrect, Cerca means distance)  You are close to me Some other words that are not translated in the proper context Some accents are missing Días always carries an accent
Okeys as Aceptar
