### PR TITLE
bug(830116): French language not updated properly in localization of FileManager component.

### DIFF
--- a/src/SfResources.fr-CH.resx
+++ b/src/SfResources.fr-CH.resx
@@ -577,7 +577,7 @@
     <value>Emplacement</value>
   </data>
   <data name="FileManager_Type" xml:space="preserve">
-    <value>Type</value>
+    <value>Taper</value>
   </data>
   <data name="FileManager_Permission" xml:space="preserve">
     <value>Autorisation</value>


### PR DESCRIPTION
The word **Type** is translated as **Taper** in French (Switzerland), so made these changes at our end.