### PR TITLE
bug(BLAZ-839907): Corrected the translation for "Uploader_Abort" in Italian

### DIFF
--- a/src/SfResources.it.resx
+++ b/src/SfResources.it.resx
@@ -226,7 +226,7 @@
     <value>Scegli un orario</value>
   </data>
   <data name="Uploader_Abort" xml:space="preserve">
-    <value>abortire</value>
+    <value>Abortire</value>
   </data>
   <data name="Uploader_Browse" xml:space="preserve">
     <value>Carica...</value>


### PR DESCRIPTION
### Bug description

Need to correct the translation for "Uploader_Abort" in Italian.

### Root cause

The name "Uploader_Abort" started with a small letter instead of a capitalized letter.

### Solution description

Now, we have updated the name "Uploader_Abort" to "Abortire" instead of "abortire" in Italian.

