### PR TITLE
corrected translation for "*save*" and "*export*"

### DIFF
--- a/src/SfResources.fa.resx
+++ b/src/SfResources.fa.resx
@@ -448,7 +448,7 @@
     <value>ايجاد كردن</value>
   </data>
   <data name="FileManager_ButtonSave" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="FileManager_HeaderNewFolder" xml:space="preserve">
     <value>پوشه</value>
@@ -688,7 +688,7 @@
     <value>اطلاعات وظیفه</value>
   </data>
   <data name="Gantt_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Gantt_Add" xml:space="preserve">
     <value>اضافه کردن</value>
@@ -724,10 +724,10 @@
     <value>بزرگنمایی برای جا دادن</value>
   </data>
   <data name="Gantt_ExcelExport" xml:space="preserve">
-    <value>صادرات اکسل</value>
+    <value>صدور اکسل</value>
   </data>
   <data name="Gantt_CsvExport" xml:space="preserve">
-    <value>صادرات CSV</value>
+    <value>صدور CSV</value>
   </data>
   <data name="Gantt_ExpandAll" xml:space="preserve">
     <value>گسترش همه</value>
@@ -805,7 +805,7 @@
     <value>تبدیل</value>
   </data>
   <data name="Gantt_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>در بالا</value>
@@ -1267,7 +1267,7 @@
     <value>بسط دادن</value>
   </data>
   <data name="PivotView_Export" xml:space="preserve">
-    <value>صادرات</value>
+    <value>صدور</value>
   </data>
   <data name="PivotView_Expression" xml:space="preserve">
     <value>اصطلاح</value>
@@ -1864,7 +1864,7 @@
     <value>نزدیک</value>
   </data>
   <data name="InPlaceEditor_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="InPlaceEditor_Cancel" xml:space="preserve">
     <value>لغو</value>
@@ -1966,7 +1966,7 @@
     <value>تنظیم مجدد</value>
   </data>
   <data name="ImageEditor_SaveBtnTooltip" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="ImageEditor_UndoTooltip" xml:space="preserve">
     <value>واگرد</value>
@@ -2143,7 +2143,7 @@
     <value>آیا مطمئن هستید که می خواهید این کارت را حذف کنید؟</value>
   </data>
   <data name="Kanban_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Kanban_Delete" xml:space="preserve">
     <value>حذف</value>
@@ -2701,16 +2701,16 @@
     <value>چاپ</value>
   </data>
   <data name="Grid_Pdfexport" xml:space="preserve">
-    <value>صادرات PDF</value>
+    <value>صدور PDF</value>
   </data>
   <data name="Grid_Excelexport" xml:space="preserve">
-    <value>صادرات اکسل</value>
+    <value>صدور اکسل</value>
   </data>
   <data name="Grid_Wordexport" xml:space="preserve">
-    <value>صادرات کلمه</value>
+    <value>صدور کلمه</value>
   </data>
   <data name="Grid_Csvexport" xml:space="preserve">
-    <value>صادرات CSV</value>
+    <value>صدور CSV</value>
   </data>
   <data name="Grid_Search" xml:space="preserve">
     <value>جستجو کردن</value>
@@ -2719,7 +2719,7 @@
     <value>ستون ها</value>
   </data>
   <data name="Grid_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Grid_Item" xml:space="preserve">
     <value>مورد</value>
@@ -2734,7 +2734,7 @@
     <value>هیچ سابقه ای برای حذف عملیات انتخاب نشده است</value>
   </data>
   <data name="Grid_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Grid_OKButton" xml:space="preserve">
     <value>خوب</value>
@@ -2824,7 +2824,7 @@
     <value>این ستون را متناسب کنید</value>
   </data>
   <data name="Grid_Export" xml:space="preserve">
-    <value>صادرات</value>
+    <value>صدور</value>
   </data>
   <data name="Grid_FirstPage" xml:space="preserve">
     <value>صفحه اول</value>
@@ -3310,10 +3310,10 @@
     <value>دو واقعه مشابه نمی توانند در همان روز اتفاق بیفتند.</value>
   </data>
   <data name="Schedule_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Schedule_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Schedule_SelectedItems" xml:space="preserve">
     <value>موارد انتخاب شدند</value>
@@ -4459,7 +4459,7 @@
     <value>نوع قالب</value>
   </data>
   <data name="DocumentEditor_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="DocumentEditor_Navigation" xml:space="preserve">
     <value>جهت یابی</value>


### PR DESCRIPTION
These are the right translations for "Save" and "Export" in this context.

"Save" => "ذخیره" or "ذخیره کردن"
"Export" => "صدور" or "صادر کردن"

and "صادرات" in English will be "Exportation"