### PR TITLE
bug(BLAZ-844600) : Change Vals to onwaar in Dutch language.

### DIFF
--- a/src/SfResources.nl.resx
+++ b/src/SfResources.nl.resx
@@ -2716,7 +2716,7 @@
     <value>waar</value>
   </data>
   <data name="Grid_False" xml:space="preserve">
-    <value>vals</value>
+    <value>onwaar</value>
   </data>
   <data name="Grid_InvalidFilterMessage" xml:space="preserve">
     <value>Ongeldige filtergegevens</value>
@@ -2917,7 +2917,7 @@
     <value>waar</value>
   </data>
   <data name="Grid_FilterFalse" xml:space="preserve">
-    <value>vals</value>
+    <value>onwaar</value>
   </data>
   <data name="Grid_NoResult" xml:space="preserve">
     <value>Geen overeenkomsten gevonden</value>


### PR DESCRIPTION
Change the incorrect term in the Dutch language. Instead of 'vals', change it to 'onwaar'.
