### PR TITLE
persian and norwegian localization improvements

### DIFF
--- a/src/SfResources.fa.resx
+++ b/src/SfResources.fa.resx
@@ -448,7 +448,7 @@
     <value>ايجاد كردن</value>
   </data>
   <data name="FileManager_ButtonSave" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="FileManager_HeaderNewFolder" xml:space="preserve">
     <value>پوشه</value>
@@ -688,7 +688,7 @@
     <value>اطلاعات وظیفه</value>
   </data>
   <data name="Gantt_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Gantt_Add" xml:space="preserve">
     <value>اضافه کردن</value>
@@ -724,10 +724,10 @@
     <value>بزرگنمایی برای جا دادن</value>
   </data>
   <data name="Gantt_ExcelExport" xml:space="preserve">
-    <value>صادرات اکسل</value>
+    <value>صدور اکسل</value>
   </data>
   <data name="Gantt_CsvExport" xml:space="preserve">
-    <value>صادرات CSV</value>
+    <value>صدور CSV</value>
   </data>
   <data name="Gantt_ExpandAll" xml:space="preserve">
     <value>گسترش همه</value>
@@ -805,7 +805,7 @@
     <value>تبدیل</value>
   </data>
   <data name="Gantt_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Gantt_Above" xml:space="preserve">
     <value>در بالا</value>
@@ -1267,7 +1267,7 @@
     <value>بسط دادن</value>
   </data>
   <data name="PivotView_Export" xml:space="preserve">
-    <value>صادرات</value>
+    <value>صدور</value>
   </data>
   <data name="PivotView_Expression" xml:space="preserve">
     <value>اصطلاح</value>
@@ -1867,7 +1867,7 @@
     <value>نزدیک</value>
   </data>
   <data name="InPlaceEditor_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="InPlaceEditor_Cancel" xml:space="preserve">
     <value>لغو</value>
@@ -1969,7 +1969,7 @@
     <value>تنظیم مجدد</value>
   </data>
   <data name="ImageEditor_SaveBtnTooltip" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="ImageEditor_UndoTooltip" xml:space="preserve">
     <value>واگرد</value>
@@ -2236,7 +2236,7 @@
     <value>آیا مطمئن هستید که می خواهید این کارت را حذف کنید؟</value>
   </data>
   <data name="Kanban_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Kanban_Delete" xml:space="preserve">
     <value>حذف</value>
@@ -2815,16 +2815,16 @@
     <value>چاپ</value>
   </data>
   <data name="Grid_Pdfexport" xml:space="preserve">
-    <value>صادرات PDF</value>
+    <value>صدور PDF</value>
   </data>
   <data name="Grid_Excelexport" xml:space="preserve">
-    <value>صادرات اکسل</value>
+    <value>صدور اکسل</value>
   </data>
   <data name="Grid_Wordexport" xml:space="preserve">
-    <value>صادرات کلمه</value>
+    <value>صدور کلمه</value>
   </data>
   <data name="Grid_Csvexport" xml:space="preserve">
-    <value>صادرات CSV</value>
+    <value>صدور CSV</value>
   </data>
   <data name="Grid_Search" xml:space="preserve">
     <value>جستجو کردن</value>
@@ -2833,7 +2833,7 @@
     <value>ستون ها</value>
   </data>
   <data name="Grid_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Grid_Item" xml:space="preserve">
     <value>مورد</value>
@@ -2848,7 +2848,7 @@
     <value>هیچ سابقه ای برای حذف عملیات انتخاب نشده است</value>
   </data>
   <data name="Grid_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Grid_OKButton" xml:space="preserve">
     <value>خوب</value>
@@ -2938,7 +2938,7 @@
     <value>این ستون را متناسب کنید</value>
   </data>
   <data name="Grid_Export" xml:space="preserve">
-    <value>صادرات</value>
+    <value>صدور</value>
   </data>
   <data name="Grid_FirstPage" xml:space="preserve">
     <value>صفحه اول</value>
@@ -3424,10 +3424,10 @@
     <value>دو واقعه مشابه نمی توانند در همان روز اتفاق بیفتند.</value>
   </data>
   <data name="Schedule_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Schedule_SaveButton" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="Schedule_SelectedItems" xml:space="preserve">
     <value>موارد انتخاب شدند</value>
@@ -4573,7 +4573,7 @@
     <value>نوع قالب</value>
   </data>
   <data name="DocumentEditor_Save" xml:space="preserve">
-    <value>صرفه جویی</value>
+    <value>ذخیره</value>
   </data>
   <data name="DocumentEditor_Navigation" xml:space="preserve">
     <value>جهت یابی</value>

--- a/src/SfResources.nb.resx
+++ b/src/SfResources.nb.resx
@@ -121,7 +121,7 @@
     <value>Forespørsel feilet</value>
   </data>
   <data name="AutoComplete_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="Calendar_Today" xml:space="preserve">
     <value>I dag</value>
@@ -130,7 +130,7 @@
     <value>Forespørsel feilet</value>
   </data>
   <data name="ComboBox_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="DatePicker_Placeholder" xml:space="preserve">
     <value>Velg en dato</value>
@@ -139,7 +139,7 @@
     <value>I dag</value>
   </data>
   <data name="DateRangePicker_ApplyText" xml:space="preserve">
-    <value>Søke om</value>
+    <value>Bruk</value>
   </data>
   <data name="DateRangePicker_CancelText" xml:space="preserve">
     <value>Avbryt</value>
@@ -193,16 +193,16 @@
     <value>Forespørsel feilet</value>
   </data>
   <data name="DropDownList_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="Mention_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="MultiSelect_ActionFailureTemplate" xml:space="preserve">
     <value>Forespørsel feilet</value>
   </data>
   <data name="MultiSelect_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="MultiSelect_OverflowCountTemplate" xml:space="preserve">
     <value>+${count} mer ..</value>
@@ -901,7 +901,7 @@
     <value>Kritisk bane</value>
   </data>
   <data name="ColorPicker_Apply" xml:space="preserve">
-    <value>Søke om</value>
+    <value>Bruk</value>
   </data>
   <data name="ColorPicker_Cancel" xml:space="preserve">
     <value>Avbryt</value>
@@ -940,7 +940,7 @@
     <value>Flytte opp</value>
   </data>
   <data name="ListBox_NoRecordsTemplate" xml:space="preserve">
-    <value>Ingen opptak funnet</value>
+    <value>Ingen poster funnet</value>
   </data>
   <data name="ListBox_SelectAllText" xml:space="preserve">
     <value>Velg alle</value>
@@ -1036,7 +1036,7 @@
     <value>og</value>
   </data>
   <data name="PivotView_Apply" xml:space="preserve">
-    <value>Søke om</value>
+    <value>Bruk</value>
   </data>
   <data name="PivotView_Area" xml:space="preserve">
     <value>Område</value>
@@ -3676,7 +3676,7 @@
     <value>Kampsak</value>
   </data>
   <data name="PdfViewer_Apply" xml:space="preserve">
-    <value>Søke om</value>
+    <value>Bruk</value>
   </data>
   <data name="PdfViewer_GoToPage" xml:space="preserve">
     <value>Gå til side</value>


### PR DESCRIPTION
Persian: 
"Save" => "ذخیره" or "ذخیره کردن"
"Export" => "صدور" or "صادر کردن"

Norwegian 
Records => "opptak" => "poster"
 























