### PR TITLE
896167: Localization Error in translating 'clear' into Portuguese

### DIFF
--- a/src/SfResources.pt.resx
+++ b/src/SfResources.pt.resx
@@ -4027,7 +4027,7 @@
     <value>Adicionar</value>
   </data>
   <data name="PdfViewer_Clear" xml:space="preserve">
-    <value>Claro</value>
+    <value>Limpar</value>
   </data>
   <data name="PdfViewer_Bold" xml:space="preserve">
     <value>Negrito</value>


### PR DESCRIPTION
The translations found in the file for 'clear' are as 'Claro'. The correct option, for the context of the action, would be 'Limpar'.

Found in the resource file:
PdfViewer_Clear -> Claro

Below is the correct translation:
PdfViewer_Clear -> Limpar

https://github.com/syncfusion/blazor-locale/issues/140