### PR TITLE
917994: Changed the Grid_SortDescription value for German Language.

### DIFF
--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -1420,7 +1420,7 @@
     <value>Ist Vorlage</value>
   </data>
   <data name="Grid_SortDescription" xml:space="preserve">
-    <value>Drücken Sie die Eingabetaste, um zu sortieren</value>
+    <value>Drücken Sie die Eingabetaste, um Zu Sortieren</value>
   </data>
   <data name="Grid_FilterDescription" xml:space="preserve">
     <value>Drücken Sie Alt Down, um das Filtermenü zu öffnen</value>

--- a/src/SfResources.de.resx
+++ b/src/SfResources.de.resx
@@ -1420,7 +1420,7 @@
     <value>Ist Vorlage</value>
   </data>
   <data name="Grid_SortDescription" xml:space="preserve">
-    <value>DRÜCKE ENTER, UM ZU CHATEN</value>
+    <value>Drücken Sie die Eingabetaste, um zu sortieren</value>
   </data>
   <data name="Grid_FilterDescription" xml:space="preserve">
     <value>Drücken Sie Alt Down, um das Filtermenü zu öffnen</value>


### PR DESCRIPTION
### Bug description
* Incorrect translation in German for "Press Enter to Sort."
### Root cause
* The phrase was previously translated to "DRÜCKE ENTER, UM ZU CHATEN," which means "Press Enter to Chat," instead of the intended "Press Enter to Sort."
### Solution description
* Corrected the German translation to "Drücken Sie die Eingabetaste, um zu sortieren," which accurately reflects "Press Enter to Sort."