### PR TITLE
Remove duplicated resource strings

### DIFF
--- a/src/SfResources.en-US.resx
+++ b/src/SfResources.en-US.resx
@@ -7715,9 +7715,7 @@
   <data name="Spreadsheet_InsertRight" xml:space="preserve">
     <value>Insert column to the right</value>
   </data>
-  <data name="Spreadsheet_Filter" xml:space="preserve">
-    <value>Filter</value>
-  </data>
+  
   <data name="Spreadsheet_File" xml:space="preserve">
     <value>File</value>
   </data>
@@ -7730,9 +7728,7 @@
   <data name="Spreadsheet_DataOperations" xml:space="preserve">
     <value>Data Operations</value>
   </data>
-  <data name="Spreadsheet_General" xml:space="preserve">
-    <value>General</value>
-  </data>
+  
   <data name="Spreadsheet_Number" xml:space="preserve">
     <value>Number</value>
   </data>
@@ -7850,9 +7846,7 @@
   <data name="Spreadsheet_Open" xml:space="preserve">
     <value>Open</value>
   </data>
-  <data name="Spreadsheet_SaveAs" xml:space="preserve">
-    <value>Save</value>
-  </data>
+  
   <data name="Spreadsheet_Print" xml:space="preserve">
     <value>Print</value>
   </data>
@@ -7907,18 +7901,14 @@
   <data name="Spreadsheet_Font" xml:space="preserve">
     <value>Font</value>
   </data>
-  <data name="Spreadsheet_Clear" xml:space="preserve">
-    <value>Clear</value>
-  </data>
+  
   <data name="Spreadsheet_Link" xml:space="preserve">
     <value>Link</value>
   </data>
   <data name="Spreadsheet_Image" xml:space="preserve">
     <value>Image</value>
   </data>
-  <data name="Spreadsheet_Home" xml:space="preserve">
-    <value>Home</value>
-  </data>
+  
   <data name="Spreadsheet_Insert" xml:space="preserve">
     <value>Insert</value>
   </data>

--- a/src/SfResources.hi-IN.resx
+++ b/src/SfResources.hi-IN.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -7904,30 +7904,16 @@
   <data name="Spreadsheet_Insert" xml:space="preserve">
     <value>डालना</value>
   </data>
-  <data name="Spreadsheet_Delete" xml:space="preserve">
-    <value>मिटाना</value>
-  </data>
-  <data name="Spreadsheet_Duplicate" xml:space="preserve">
-    <value>डुप्लिकेट</value>
-  </data>
-  <data name="Spreadsheet_Rename" xml:space="preserve">
-    <value>नाम बदलें</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_ProtectSheet" xml:space="preserve">
     <value>बचा हुआ चादर</value>
   </data>
-  <data name="Spreadsheet_MoveRight" xml:space="preserve">
-    <value>सही कदम</value>
-  </data>
-  <data name="Spreadsheet_MoveLeft" xml:space="preserve">
-    <value>बाएं खिसको</value>
-  </data>
-  <data name="Spreadsheet_Copy" xml:space="preserve">
-    <value>काटना</value>
-  </data>
-  <data name="Spreadsheet_Paste" xml:space="preserve">
-    <value>पेस्ट करें</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Hyperlink" xml:space="preserve">
     <value>हाइपरलिंक</value>
   </data>

--- a/src/SfResources.hu.resx
+++ b/src/SfResources.hu.resx
@@ -8343,27 +8343,17 @@
   <data name="Spreadsheet_Font" xml:space="preserve">
     <value>Betűtípus</value>
   </data>
-  <data name="Spreadsheet_Clear" xml:space="preserve">
-    <value>Egyértelmű</value>
-  </data>
-  <data name="Spreadsheet_Image" xml:space="preserve">
-    <value>Kép</value>
-  </data>
-  <data name="Spreadsheet_Link" xml:space="preserve">
-    <value>Link</value>
-  </data>
-  <data name="Spreadsheet_New" xml:space="preserve">
-    <value>Új</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Clipboard" xml:space="preserve">
     <value>Vágólap</value>
   </data>
   <data name="Spreadsheet_ChangeCase" xml:space="preserve">
     <value>Változtatási eset</value>
   </data>
-  <data name="Spreadsheet_Open" xml:space="preserve">
-    <value>Nyisd ki</value>
-  </data>
+  
   <data name="Spreadsheet_Print" xml:space="preserve">
     <value>Nyomtatás</value>
   </data>
@@ -8385,30 +8375,20 @@
   <data name="Spreadsheet_Justify" xml:space="preserve">
     <value>indokol</value>
   </data>
-  <data name="Spreadsheet_ClearAll" xml:space="preserve">
-    <value>Mindent kitöröl</value>
-  </data>
+  
   <data name="Spreadsheet_Descending" xml:space="preserve">
     <value>Csökkenő</value>
   </data>
   <data name="Spreadsheet_Ascending" xml:space="preserve">
     <value>növekvő</value>
   </data>
-  <data name="Spreadsheet_Home" xml:space="preserve">
-    <value>Otthon</value>
-  </data>
+  
   <data name="Spreadsheet_CustomSort" xml:space="preserve">
     <value>Gondoskodás</value>
   </data>
-  <data name="Spreadsheet_ClearHyperlinks" xml:space="preserve">
-    <value>Tisztítsa meg a hiperhivatkozásokat</value>
-  </data>
-  <data name="Spreadsheet_ClearFormats" xml:space="preserve">
-    <value>Tiszta formátumok</value>
-  </data>
-  <data name="Spreadsheet_ClearContents" xml:space="preserve">
-    <value>Egyértelmű tartalom</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_KeepTextOnly" xml:space="preserve">
     <value>Csak a szöveget tartsa meg</value>
   </data>
@@ -8418,9 +8398,7 @@
   <data name="Spreadsheet_MergeFormat" xml:space="preserve">
     <value>Egyesítse a formátumot</value>
   </data>
-  <data name="Spreadsheet_SaveAs" xml:space="preserve">
-    <value>Mentse el</value>
-  </data>
+  
   <data name="Spreadsheet_Arial" xml:space="preserve">
     <value>Arial</value>
   </data>
@@ -8508,15 +8486,9 @@
   <data name="Spreadsheet_DownloadPDF" xml:space="preserve">
     <value>Töltse le PDF -ként</value>
   </data>
-  <data name="Spreadsheet_Filter" xml:space="preserve">
-    <value>Szűrő</value>
-  </data>
-  <data name="Spreadsheet_File" xml:space="preserve">
-    <value>Irat</value>
-  </data>
-  <data name="Spreadsheet_Sort" xml:space="preserve">
-    <value>Fajta</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_AlignBottom" xml:space="preserve">
     <value>Alul igazítsa</value>
   </data>
@@ -8526,15 +8498,9 @@
   <data name="Spreadsheet_AlignTop" xml:space="preserve">
     <value>Igazítsa a tetejét</value>
   </data>
-  <data name="Spreadsheet_InsertLeft" xml:space="preserve">
-    <value>Helyezze be az oszlopot balra</value>
-  </data>
-  <data name="Spreadsheet_InsertRight" xml:space="preserve">
-    <value>Helyezze be az oszlop jobbra</value>
-  </data>
-  <data name="Spreadsheet_InsertRowsAbove" xml:space="preserve">
-    <value>Helyezze be a fenti sorokat</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_InsertRowBelow" xml:space="preserve">
     <value>Helyezzen be sorokat az alábbiakba</value>
   </data>

--- a/src/SfResources.ja.resx
+++ b/src/SfResources.ja.resx
@@ -8340,42 +8340,24 @@
   <data name="RichTextEditor_CodeBlock" xml:space="preserve">
     <value>コードブロックを挿入</value>
   </data>
-  <data name="Spreadsheet_Bold" xml:space="preserve">
-    <value>大胆な</value>
-  </data>
-  <data name="Spreadsheet_Italic" xml:space="preserve">
-    <value>イタリック</value>
-  </data>
-  <data name="Spreadsheet_Underline" xml:space="preserve">
-    <value>下線</value>
-  </data>
-  <data name="Spreadsheet_Strikethrough" xml:space="preserve">
-    <value>取り消し線</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Font" xml:space="preserve">
     <value>フォント</value>
   </data>
-  <data name="Spreadsheet_Clear" xml:space="preserve">
-    <value>晴れ</value>
-  </data>
-  <data name="Spreadsheet_Image" xml:space="preserve">
-    <value>画像</value>
-  </data>
-  <data name="Spreadsheet_Link" xml:space="preserve">
-    <value>リンク</value>
-  </data>
-  <data name="Spreadsheet_New" xml:space="preserve">
-    <value>新着</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Clipboard" xml:space="preserve">
     <value>クリップボード</value>
   </data>
   <data name="Spreadsheet_ChangeCase" xml:space="preserve">
     <value>ケースを変更します</value>
   </data>
-  <data name="Spreadsheet_Open" xml:space="preserve">
-    <value>開いた</value>
-  </data>
+  
   <data name="Spreadsheet_Print" xml:space="preserve">
     <value>印刷する</value>
   </data>
@@ -8397,30 +8379,20 @@
   <data name="Spreadsheet_Justify" xml:space="preserve">
     <value>正当化する</value>
   </data>
-  <data name="Spreadsheet_ClearAll" xml:space="preserve">
-    <value>すべてクリア</value>
-  </data>
+  
   <data name="Spreadsheet_Descending" xml:space="preserve">
     <value>降順</value>
   </data>
   <data name="Spreadsheet_Ascending" xml:space="preserve">
     <value>上昇</value>
   </data>
-  <data name="Spreadsheet_Home" xml:space="preserve">
-    <value>家</value>
-  </data>
+  
   <data name="Spreadsheet_CustomSort" xml:space="preserve">
     <value>税関</value>
   </data>
-  <data name="Spreadsheet_ClearHyperlinks" xml:space="preserve">
-    <value>クリアハイパーリンク</value>
-  </data>
-  <data name="Spreadsheet_ClearFormats" xml:space="preserve">
-    <value>クリアフォーマット</value>
-  </data>
-  <data name="Spreadsheet_ClearContents" xml:space="preserve">
-    <value>クリアコンテンツ</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_KeepTextOnly" xml:space="preserve">
     <value>テキストのみを保持します</value>
   </data>
@@ -8430,9 +8402,7 @@
   <data name="Spreadsheet_MergeFormat" xml:space="preserve">
     <value>マージフォーマット</value>
   </data>
-  <data name="Spreadsheet_SaveAs" xml:space="preserve">
-    <value>ASを保存します</value>
-  </data>
+  
   <data name="Spreadsheet_Arial" xml:space="preserve">
     <value>Arial</value>
   </data>
@@ -8520,15 +8490,9 @@
   <data name="Spreadsheet_DownloadPDF" xml:space="preserve">
     <value>PDFとしてダウンロードします</value>
   </data>
-  <data name="Spreadsheet_Filter" xml:space="preserve">
-    <value>フィルタ</value>
-  </data>
-  <data name="Spreadsheet_File" xml:space="preserve">
-    <value>ファイル</value>
-  </data>
-  <data name="Spreadsheet_Sort" xml:space="preserve">
-    <value>ソート</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_AlignBottom" xml:space="preserve">
     <value>下揃え</value>
   </data>
@@ -8538,15 +8502,9 @@
   <data name="Spreadsheet_AlignTop" xml:space="preserve">
     <value>上揃え</value>
   </data>
-  <data name="Spreadsheet_InsertLeft" xml:space="preserve">
-    <value>左に列を挿入します</value>
-  </data>
-  <data name="Spreadsheet_InsertRight" xml:space="preserve">
-    <value>列を右に挿入します</value>
-  </data>
-  <data name="Spreadsheet_InsertRowsAbove" xml:space="preserve">
-    <value>上に行を挿入</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_InsertRowBelow" xml:space="preserve">
     <value>下に行を挿入</value>
   </data>

--- a/src/SfResources.th.resx
+++ b/src/SfResources.th.resx
@@ -8331,42 +8331,24 @@
   <data name="RichTextEditor_CodeBlock" xml:space="preserve">
     <value>การแทรกบล็อคโค้ด</value>
   </data>
-  <data name="Spreadsheet_Bold" xml:space="preserve">
-    <value>กล้า</value>
-  </data>
-  <data name="Spreadsheet_Italic" xml:space="preserve">
-    <value>ตัวเอียง</value>
-  </data>
-  <data name="Spreadsheet_Underline" xml:space="preserve">
-    <value>ขีดเส้นใต้</value>
-  </data>
-  <data name="Spreadsheet_Strikethrough" xml:space="preserve">
-    <value>ขีดฆ่า</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Font" xml:space="preserve">
     <value>ตัวอักษร</value>
   </data>
-  <data name="Spreadsheet_Clear" xml:space="preserve">
-    <value>ชัดเจน</value>
-  </data>
-  <data name="Spreadsheet_Image" xml:space="preserve">
-    <value>ภาพ</value>
-  </data>
-  <data name="Spreadsheet_Link" xml:space="preserve">
-    <value>ลิงค์</value>
-  </data>
-  <data name="Spreadsheet_New" xml:space="preserve">
-    <value>ใหม่</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Clipboard" xml:space="preserve">
     <value>คลิปบอร์ด</value>
   </data>
   <data name="Spreadsheet_ChangeCase" xml:space="preserve">
     <value>เปลี่ยนเคส</value>
   </data>
-  <data name="Spreadsheet_Open" xml:space="preserve">
-    <value>เปิด</value>
-  </data>
+  
   <data name="Spreadsheet_Print" xml:space="preserve">
     <value>พิมพ์</value>
   </data>
@@ -8388,30 +8370,18 @@
   <data name="Spreadsheet_Justify" xml:space="preserve">
     <value>แสดงให้เห็นถึง</value>
   </data>
-  <data name="Spreadsheet_ClearAll" xml:space="preserve">
-    <value>ลบทั้งหมด</value>
-  </data>
+  
   <data name="Spreadsheet_Descending" xml:space="preserve">
     <value>Descending</value>
   </data>
   <data name="Spreadsheet_Ascending" xml:space="preserve">
     <value>จากน้อยไปมาก</value>
   </data>
-  <data name="Spreadsheet_Home" xml:space="preserve">
-    <value>บ้าน</value>
-  </data>
-  <data name="Spreadsheet_CustomSort" xml:space="preserve">
-    <value>ศุลกากร</value>
-  </data>
-  <data name="Spreadsheet_ClearHyperlinks" xml:space="preserve">
-    <value>ไฮเปอร์ลิงก์ที่ชัดเจน</value>
-  </data>
-  <data name="Spreadsheet_ClearFormats" xml:space="preserve">
-    <value>รูปแบบที่ชัดเจน</value>
-  </data>
-  <data name="Spreadsheet_ClearContents" xml:space="preserve">
-    <value>เนื้อหาที่ชัดเจน</value>
-  </data>
+  
+  
+  
+  
+  
   <data name="Spreadsheet_KeepTextOnly" xml:space="preserve">
     <value>เก็บข้อความเท่านั้น</value>
   </data>
@@ -8424,9 +8394,7 @@
   <data name="Spreadsheet_Reapply" xml:space="preserve">
     <value>นำกลับมาใช้ใหม่</value>
   </data>
-  <data name="Spreadsheet_SaveAs" xml:space="preserve">
-    <value>ประหยัด</value>
-  </data>
+  
   <data name="Spreadsheet_Arial" xml:space="preserve">
     <value>Arial</value>
   </data>
@@ -8517,9 +8485,7 @@
   <data name="Spreadsheet_Filter" xml:space="preserve">
     <value>กรอง</value>
   </data>
-  <data name="Spreadsheet_File" xml:space="preserve">
-    <value>ไฟล์</value>
-  </data>
+  
   <data name="Spreadsheet_File_Duplicate[1]" xml:space="preserve">
     <value>ประเภท</value>
   </data>
@@ -8532,15 +8498,9 @@
   <data name="Spreadsheet_AlignTop" xml:space="preserve">
     <value>จัดเรียงด้านบน</value>
   </data>
-  <data name="Spreadsheet_InsertLeft" xml:space="preserve">
-    <value>แทรกคอลัมน์ไปทางซ้าย</value>
-  </data>
-  <data name="Spreadsheet_InsertRight" xml:space="preserve">
-    <value>แทรกคอลัมน์ไปทางขวา</value>
-  </data>
-  <data name="Spreadsheet_InsertRowsAbove" xml:space="preserve">
-   <value>แทรกแถวด้านบน</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_InsertRowBelow" xml:space="preserve">
     <value>แทรกแถวด้านล่าง</value>
   </data>

--- a/src/SfResources.tr.resx
+++ b/src/SfResources.tr.resx
@@ -8277,42 +8277,24 @@
   <data name="RichTextEditor_CodeBlock" xml:space="preserve">
     <value>Kod Bloğu Ekle</value>
   </data>
-  <data name="Spreadsheet_Bold" xml:space="preserve">
-    <value>cesur</value>
-  </data>
-  <data name="Spreadsheet_Italic" xml:space="preserve">
-    <value>İtalik</value>
-  </data>
-  <data name="Spreadsheet_Underline" xml:space="preserve">
-    <value>Altını çizmek</value>
-  </data>
-  <data name="Spreadsheet_Strikethrough" xml:space="preserve">
-    <value>Üstü çizili</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Font" xml:space="preserve">
     <value>Yazı tipi</value>
   </data>
-  <data name="Spreadsheet_Clear" xml:space="preserve">
-    <value>Temizlemek</value>
-  </data>
-  <data name="Spreadsheet_Image" xml:space="preserve">
-    <value>görüntü</value>
-  </data>
-  <data name="Spreadsheet_Link" xml:space="preserve">
-    <value>bağlantı</value>
-  </data>
-  <data name="Spreadsheet_New" xml:space="preserve">
-    <value>Yeni</value>
-  </data>
+  
+  
+  
+  
   <data name="Spreadsheet_Clipboard" xml:space="preserve">
     <value>Pano</value>
   </data>
   <data name="Spreadsheet_ChangeCase" xml:space="preserve">
     <value>Değişim davası</value>
   </data>
-  <data name="Spreadsheet_Open" xml:space="preserve">
-    <value>Açık</value>
-  </data>
+  
   <data name="Spreadsheet_Print" xml:space="preserve">
     <value>Yazdır</value>
   </data>
@@ -8334,30 +8316,18 @@
   <data name="Spreadsheet_Justify" xml:space="preserve">
     <value>haklı çıkarmak</value>
   </data>
-  <data name="Spreadsheet_ClearAll" xml:space="preserve">
-    <value>Hepsini temizle</value>
-  </data>
+  
   <data name="Spreadsheet_Descending" xml:space="preserve">
     <value>Azalan</value>
   </data>
   <data name="Spreadsheet_Ascending" xml:space="preserve">
     <value>Artan</value>
   </data>
-  <data name="Spreadsheet_Home" xml:space="preserve">
-    <value>Ev</value>
-  </data>
-  <data name="Spreadsheet_CustomSort" xml:space="preserve">
-    <value>Gümrük</value>
-  </data>
-  <data name="Spreadsheet_ClearHyperlinks" xml:space="preserve">
-    <value>Temiz köprüler</value>
-  </data>
-  <data name="Spreadsheet_ClearFormats" xml:space="preserve">
-    <value>Formatları Temizle</value>
-  </data>
-  <data name="Spreadsheet_ClearContents" xml:space="preserve">
-    <value>Net içerik</value>
-  </data>
+  
+  
+  
+  
+  
   <data name="Spreadsheet_KeepTextOnly" xml:space="preserve">
     <value>Yalnızca metni saklayın</value>
   </data>
@@ -8370,9 +8340,7 @@
   <data name="Spreadsheet_Reapply" xml:space="preserve">
     <value>Yeniden uygulamak</value>
   </data>
-  <data name="Spreadsheet_SaveAs" xml:space="preserve">
-    <value>Tasarruf etmek</value>
-  </data>
+  
   <data name="Spreadsheet_Arial" xml:space="preserve">
     <value>Arial</value>
   </data>
@@ -8463,12 +8431,8 @@
   <data name="Spreadsheet_Filter" xml:space="preserve">
     <value>filtre</value>
   </data>
-  <data name="Spreadsheet_File" xml:space="preserve">
-    <value>Dosya</value>
-  </data>
-  <data name="Spreadsheet_Sort" xml:space="preserve">
-    <value>Çeşit</value>
-  </data>
+  
+  
   <data name="Spreadsheet_AlignBottom" xml:space="preserve">
     <value>Alta Hizala</value>
   </data>
@@ -8478,15 +8442,9 @@
   <data name="Spreadsheet_AlignTop" xml:space="preserve">
     <value>Üste Hizala</value>
   </data>
-  <data name="Spreadsheet_InsertLeft" xml:space="preserve">
-    <value>Sola sütun ekle</value>
-  </data>
-  <data name="Spreadsheet_InsertRight" xml:space="preserve">
-    <value>Sağdaki sütun ekleyin</value>
-  </data>
-  <data name="Spreadsheet_InsertRowsAbove" xml:space="preserve">
-    <value>Yukarıdaki satırları ekle</value>
-  </data>
+  
+  
+  
   <data name="Spreadsheet_InsertRowBelow" xml:space="preserve">
     <value>Aşağıya satır ekle</value>
   </data>


### PR DESCRIPTION
Deleted several duplicated  resource strings from multiple localization files (en-US, hi-IN, hu, ja, th, tr) to clean up and streamline resource management. MSB3568: No se permite el nombre de recurso duplicado "Spreadsheet_Filter". Se omitirá. 1>Resources\SfResources.en-US.resx : warning MSB3568: No se permite el nombre de recurso duplicado "Spreadsheet_General". Se omitirá The warning message is in spanish
I preserve the first ocurrence and delete the other