### PR TITLE
971600: Change MultiSelect_OverflowCountTemplate for pt-BR

### DIFF
--- a/src/SfResources.pt-BR.resx
+++ b/src/SfResources.pt-BR.resx
@@ -202,7 +202,7 @@
     <value>Nenhum registro foi encontrado</value>
   </data>
   <data name="MultiSelect_OverflowCountTemplate" xml:space="preserve">
-    <value>+${contar} mais..</value>
+    <value>+${count} mais..</value>
   </data>
   <data name="MultiSelect_SelectAllText" xml:space="preserve">
     <value>Selecionar tudo</value>


### PR DESCRIPTION
### Description

- In the pt-BR culture resource file the `MultiSelect_OverflowCountTemplate` translation was updated wrongly it converted the programmatic count word also.

### Changes Made:
Replaced ${contar} with ${count} in the overflow count template to ensure displays the correct count and maintains consistency across localized strings.
