### PR TITLE
v30.2.4

### DIFF
--- a/src/SfResources.ja.resx
+++ b/src/SfResources.ja.resx
@@ -247,7 +247,7 @@
     <value>キャンセル</value>
   </data>
   <data name="Uploader_Clear" xml:space="preserve">
-    <value>晴れ</value>
+    <value>クリア</value>
   </data>
   <data name="Uploader_Delete" xml:space="preserve">
     <value>ファイルを削除する</value>
@@ -1153,10 +1153,10 @@
     <value>チャート</value>
   </data>
   <data name="PivotView_Clear" xml:space="preserve">
-    <value>晴れ</value>
+    <value>クリア</value>
   </data>
   <data name="PivotView_ClearFilter" xml:space="preserve">
-    <value>晴れ</value>
+    <value>クリア</value>
   </data>
   <data name="PivotView_Close" xml:space="preserve">
     <value>閉じる</value>
@@ -3004,7 +3004,7 @@
     <value>フィルタ</value>
   </data>
   <data name="Grid_ClearButton" xml:space="preserve">
-    <value>晴れ</value>
+    <value>クリア</value>
   </data>
   <data name="Grid_IsNull" xml:space="preserve">
     <value>ヌル</value>
@@ -4423,7 +4423,7 @@
     <value>追加</value>
   </data>
   <data name="PdfViewer_Clear" xml:space="preserve">
-    <value>晴れ</value>
+    <value>クリア</value>
   </data>
   <data name="PdfViewer_Bold" xml:space="preserve">
     <value>大胆な</value>


### PR DESCRIPTION
### Description

Updated Japanese word “晴れ” (meaning sunny/clear weather) is incorrect in this context.
It should be corrected to “クリア” (clear) to be accurate in Japanese.